### PR TITLE
Fix CLI env parsing

### DIFF
--- a/src/mcpo/__init__.py
+++ b/src/mcpo/__init__.py
@@ -74,7 +74,7 @@ def main(
     env_dict = {}
     if env:
         for var in env:
-            key, value = env.split("=", 1)
+            key, value = var.split("=", 1)
             env_dict[key] = value
 
     # Set environment variables


### PR DESCRIPTION
## Summary
- fix environment variable parsing in CLI

## Testing
- `python -m py_compile src/mcpo/__init__.py src/mcpo/main.py src/mcpo/utils/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68456d5bc2248323a891f8ab39296d41